### PR TITLE
Modify PyGame button click behaviour for countries-activity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+/locale
+/dist-xo

--- a/Countries.py
+++ b/Countries.py
@@ -163,10 +163,8 @@ class Countries:
                 flushing = True
 
     def proximity(self, up, down):
-        x_max, y_max = down.pos
-        x_min, y_min = down.pos
-        if(up.pos[0] <= (x_max + 30) and up.pos[0] >= (x_min - 30)):
-            if(up.pos[1] <= (y_max + 30) and up.pos[1] >= (y_min - 30)):
+        if(up.pos[0] <= (down.pos[0] + 30) and up.pos[0] >= (down.pos[0] - 30)):
+            if(up.pos[1] <= (down.pos[1] + 30) and up.pos[1] >= (down.pos[1] - 30)):
                 return True
         return False
 

--- a/Countries.py
+++ b/Countries.py
@@ -162,6 +162,14 @@ class Countries:
             for event in pygame.event.get():
                 flushing = True
 
+    def proximity(self, up, down):
+        x_max, y_max = down.pos
+        x_min, y_min = down.pos
+        if(up.pos[0] <= (x_max + 30) and up.pos[0] >= (x_min - 30)):
+            if(up.pos[1] <= (y_max + 30) and up.pos[1] >= (y_min - 30)):
+                return True
+        return False
+
     def run(self):
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
@@ -182,12 +190,12 @@ class Countries:
             self.canvas.grab_focus()
         ctrl = False
         going = True
+        down_event = None
         while going:
             if self.journal:
                 # Pump Gtk messages.
                 while Gtk.events_pending():
                     Gtk.main_iteration()
-
             # Pump PyGame messages.
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
@@ -200,16 +208,21 @@ class Countries:
                     if self.canvas is not None:
                         self.canvas.grab_focus()
                 elif event.type == pygame.MOUSEBUTTONDOWN:
+                    # Store the latest MOUSEBUTTONDOWN event
+                    if event.button == 1:
+                        down_event = event
+                elif event.type == pygame.MOUSEBUTTONUP:
                     g.redraw = True
                     self.ctry.message = None
                     g.pic = g.globe
                     if event.button == 1:
-                        if self.do_click():
-                            pass
-                        else:
-                            bu = buttons.check()
-                            if bu != '':
-                                self.do_button(bu)
+                        if self.proximity(event, down_event):
+                            if self.do_click():
+                                pass
+                            else:
+                                bu = buttons.check()
+                                if bu != '':
+                                    self.do_button(bu)
                         self.flush_queue()
                     if event.button == 3:
                         self.ctry.clear()


### PR DESCRIPTION
Fixes #2 
**Updates**
1) The click event is handled at `MOUSEBUTTONUP` event rather than `MOUSEBUTTONDOWN`. This change prevents the double-click event to be executed twice on the second click. For more reference: https://github.com/sugarlabs/countries-activity/issues/2

Mouse button checklist

- [x] move pointer inside button, press mouse button, release; the button shall activate.
- [x] move pointer outside button, press mouse button, move pointer inside button, release; the button shall not activate.
- [x] move pointer inside button, press mouse button, move pointer outside button, release; the button shall not activate.

The above patch ensures the checklist is satisfied. 
Tested on Ubuntu 18.04 Sugar v0.114