### PR TITLE
Fixed initialization order and prevent crash when no sound device is available

### DIFF
--- a/Countries.py
+++ b/Countries.py
@@ -29,11 +29,21 @@ class Countries:
     def __init__(self):
         self.journal = True  # set to False if we come in via main()
         self.canvas = None  # set to the pygame canvas if we come in via activity.py
-        self.click_sound = pygame.mixer.Sound("data/sounds/clicksound.ogg")
-        self.click_sound.set_volume(0.4)
-        self.correct_ans_sound = pygame.mixer.Sound("data/sounds/correctans.ogg")
-        self.wrong_ans_sound = pygame.mixer.Sound("data/sounds/wrongans.ogg")
-        self.correct_ans_sound.set_volume(0.6)
+        self.click_sound = None
+        self.correct_ans_sound = None
+        self.wrong_ans_sound = None
+    
+    def init_sound(self):
+        try:
+            self.click_sound = pygame.mixer.Sound("data/sounds/clicksound.ogg")
+            self.click_sound.set_volume(0.4)
+            self.correct_ans_sound = pygame.mixer.Sound("data/sounds/correctans.ogg")
+            self.wrong_ans_sound = pygame.mixer.Sound("data/sounds/wrongans.ogg")
+            self.correct_ans_sound.set_volume(0.6)
+        except pygame.error:
+            self.click_sound = None
+            self.correct_ans_sound = None
+            self.wrong_ans_sound = None
 
     def display(self):
         if g.map1:
@@ -179,7 +189,8 @@ class Countries:
         ctry.text(l, answer_fix)
         self.ctry.message = "Good job, " + \
                             ans + " is the right answer!"
-        self.correct_ans_sound.play()
+        if self.correct_ans_sound is not None:
+            self.correct_ans_sound.play()
 
     def proximity(self, up, down):
         if(up.pos[0] <= (down.pos[0] + 30) and up.pos[0] >= (down.pos[0] - 30)):
@@ -188,8 +199,11 @@ class Countries:
         return False
 
     def run(self):
-        pygame.mixer.music.load("data/sounds/theme.ogg")
-        pygame.mixer.music.play(-1)
+        try:
+            pygame.mixer.music.load("data/sounds/theme.ogg")
+            pygame.mixer.music.play(-1)
+        except pygame.error:
+            pass
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 return
@@ -230,7 +244,8 @@ class Countries:
                         self.canvas.grab_focus()
                 elif event.type == pygame.MOUSEBUTTONDOWN:
                     # Store the latest MOUSEBUTTONDOWN event
-                    self.click_sound.play()
+                    if self.click_sound is not None:
+                        self.click_sound.play()
                     if event.button == 1:
                         down_event = event
                 elif event.type == pygame.MOUSEBUTTONUP:
@@ -285,7 +300,8 @@ class Countries:
                             
                             self.ctry.message = "Sorry, " + self.ctry.answer +\
                                                 " is not on my list"
-                            self.wrong_ans_sound.play()
+                            if self.wrong_ans_sound is not None:
+                                self.wrong_ans_sound.play()
                         self.ctry.answer = ''
                         answer_input = False
                     g.redraw = True

--- a/activity.py
+++ b/activity.py
@@ -44,10 +44,11 @@ class PeterActivity(activity.Activity):
 
         # Build the Pygame canvas.
         self.game.canvas = self._pygamecanvas = sugargame.canvas.PygameCanvas(
-            self, main=self.game.run, modules=[pygame.display, pygame.font])
+            self, main=self.game.run, modules=[pygame.display, pygame.font, pygame.mixer])
         # Note that set_canvas implicitly calls
         # read_file when resuming from the Journal.
         self.set_canvas(self._pygamecanvas)
+        self.game.init_sound()
 
     def read_file(self, file_path):
         try:

--- a/ctry.py
+++ b/ctry.py
@@ -62,8 +62,12 @@ class Ctry:
             for w in c:
                 self.dup_countries.append(w)
         
-        self.correct_ans_sound = pygame.mixer.Sound("data/sounds/correctans.ogg")
-        self.wrong_ans_sound = pygame.mixer.Sound("data/sounds/wrongans.ogg")
+        try:
+            self.correct_ans_sound = pygame.mixer.Sound("data/sounds/correctans.ogg")
+            self.wrong_ans_sound = pygame.mixer.Sound("data/sounds/wrongans.ogg")
+        except pygame.error:
+            self.correct_ans_sound = None
+            self.wrong_ans_sound = None
 
 
     def setup(self):
@@ -127,7 +131,8 @@ class Ctry:
         value, ans = self.check(answer_fix)
         if ans is None or value == -1:
             self.message = 'Sorry, ' + self.answer + ' is not in my list'
-            self.wrong_ans_sound.play()
+            if self.wrong_ans_sound is not None:
+                self.wrong_ans_sound.play()
             return -1
         if value == 0:
             self.message = 'Did you mean ' + ans + '? (y/n)'
@@ -136,7 +141,8 @@ class Ctry:
             g.answers[ind] = ''
             self.redraw()
         self.message = "Correct, you got it right"
-        self.correct_ans_sound.play()
+        if self.correct_ans_sound is not None:
+            self.correct_ans_sound.play()
         g.answers[ind] = ans
         self.flag(ans)
         text(l, answer_fix)


### PR DESCRIPTION
This change makes sound initialization optional so the activity can still run when no sound device is available. Sound loading is put within a try/except block so sounds and background music are only played if they were successfully loaded.

The activity runs correctly on my end with sound. Could you please check if this also works in your container environment without a sound device?