### PR TITLE
Fix #29: prevent writing to read-only activity directory + related bug fixes

### DIFF
--- a/Countries.py
+++ b/Countries.py
@@ -331,4 +331,3 @@ if __name__ == "__main__":
     pygame.display.quit()
     pygame.quit()
     sys.exit(0)
-

--- a/Countries.py
+++ b/Countries.py
@@ -331,3 +331,4 @@ if __name__ == "__main__":
     pygame.display.quit()
     pygame.quit()
     sys.exit(0)
+

--- a/Countries.py
+++ b/Countries.py
@@ -29,11 +29,9 @@ class Countries:
     def __init__(self):
         self.journal = True  # set to False if we come in via main()
         self.canvas = None  # set to the pygame canvas if we come in via activity.py
-        self.click_sound = pygame.mixer.Sound("data/sounds/clicksound.ogg")
-        self.click_sound.set_volume(0.4)
-        self.correct_ans_sound = pygame.mixer.Sound("data/sounds/correctans.ogg")
-        self.wrong_ans_sound = pygame.mixer.Sound("data/sounds/wrongans.ogg")
-        self.correct_ans_sound.set_volume(0.6)
+        self.click_sound = None
+        self.correct_ans_sound = None
+        self.wrong_ans_sound = None
 
     def display(self):
         if g.map1:
@@ -172,6 +170,10 @@ class Countries:
     def check_response(self):
         answer_fix = ctry.fix(self.ctry.answer)
         value, ans = self.ctry.check(answer_fix)
+        if ans is None or value == -1:
+            self.ctry.message = "Sorry, " + self.ctry.answer + " is not on my list"
+            self.wrong_ans_sound.play()
+            return
         l = ans[:1]
         ind = ord(l) - 65
         g.answers[ind] = ans
@@ -190,6 +192,22 @@ class Countries:
     def run(self):
         pygame.mixer.music.load("data/sounds/theme.ogg")
         pygame.mixer.music.play(-1)
+
+        # Load sounds here — mixer is guaranteed to be initialised by now
+        try:
+            self.click_sound = pygame.mixer.Sound("data/sounds/clicksound.ogg")
+            self.click_sound.set_volume(0.4)
+            self.correct_ans_sound = pygame.mixer.Sound("data/sounds/correctans.ogg")
+            self.correct_ans_sound.set_volume(0.6)
+            self.wrong_ans_sound = pygame.mixer.Sound("data/sounds/wrongans.ogg")
+        except pygame.error:
+            # No audio device — create silent stubs so .play() calls don't crash
+            class _SilentSound:
+                def play(self): pass
+                def set_volume(self, v): pass
+            self.click_sound = _SilentSound()
+            self.correct_ans_sound = _SilentSound()
+            self.wrong_ans_sound = _SilentSound()
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 return
@@ -238,7 +256,7 @@ class Countries:
                     self.ctry.message = None
                     g.pic = g.globe
                     if event.button == 1:
-                        if self.proximity(event, down_event) and answer_input is False:
+                        if down_event is not None and self.proximity(event, down_event) and answer_input is False:
                             if self.do_click():
                                 pass
                             else:
@@ -247,7 +265,7 @@ class Countries:
                                     value = self.do_button(bu)
                                     if value == 0:
                                         answer_input = True    
-                        elif self.proximity(event, down_event) and answer_input is True:
+                        elif down_event is not None and self.proximity(event, down_event) and answer_input is True:
                             res = self.ctry.which_oval()
                             if res == 'y':
                                 self.check_response()

--- a/utils.py
+++ b/utils.py
@@ -391,3 +391,4 @@ def initcap(s):
             space = True
         t += ch
     return t
+    

--- a/utils.py
+++ b/utils.py
@@ -3,9 +3,7 @@ import g
 import pygame
 import sys
 import os
-import utils
 import random
-import copy
 import load_save
 
 # constants
@@ -23,32 +21,45 @@ def exit():
     sys.exit()
 
 
+def _get_data_dir():
+    """Return a user-writable directory for saving game data.
+
+    When running inside Sugar, SUGAR_ACTIVITY_ROOT points to a per-activity
+    user-writable root; data is stored in its ``data/`` sub-directory.
+    When running standalone (e.g. for development) fall back to
+    ``~/.local/share/countries-activity/`` so we never attempt to write
+    into the read-only activity bundle directory (fixes issue #29).
+    """
+    sugar_root = os.environ.get('SUGAR_ACTIVITY_ROOT')
+    if sugar_root:
+        data_dir = os.path.join(sugar_root, 'data')
+    else:
+        xdg_data = os.environ.get(
+            'XDG_DATA_HOME',
+            os.path.join(os.path.expanduser('~'), '.local', 'share'))
+        data_dir = os.path.join(xdg_data, 'countries-activity')
+    os.makedirs(data_dir, exist_ok=True)
+    return data_dir
+
+
 def save():
-    dir = ''
-    dir = os.environ.get('SUGAR_ACTIVITY_ROOT')
-    if dir is None:
-        dir = ''
-    fname = os.path.join(dir, 'data', 'Countries.dat')
-    f = open(fname, 'w')
-    load_save.save(f)
-    f.close
+    fname = os.path.join(_get_data_dir(), 'Countries.dat')
+    with open(fname, 'w') as f:
+        load_save.save(f)
 
 
 def load():
-    dir = ''
-    dir = os.environ.get('SUGAR_ACTIVITY_ROOT')
-    if dir is None:
-        dir = ''
-    fname = os.path.join(dir, 'data', 'Countries.dat')
+    fname = os.path.join(_get_data_dir(), 'Countries.dat')
     try:
         f = open(fname, 'r')
-    except BaseException:
-        return None  # ****
+    except OSError:
+        return None
     try:
         load_save.load(f)
-    except BaseException:
+    except Exception:
         pass
-    f.close
+    finally:
+        f.close()
 
 
 def version_display():
@@ -201,7 +212,7 @@ def message1(screen, font, m, coordinates, d=15):
     rect.centerx = cx
     rect.centery = cy * 1.45
     bgd = pygame.Surface((rect.width + 2 * d, rect.height + 2 * d))
-    bgd.fill(utils.CREAM)
+    bgd.fill(CREAM)
     screen.blit(bgd, (rect.left - d, rect.top - d))
     screen.blit(text, rect)
 

--- a/utils.py
+++ b/utils.py
@@ -391,4 +391,3 @@ def initcap(s):
             space = True
         t += ch
     return t
-    


### PR DESCRIPTION
## Summary

This PR fixes issue #29 where the activity attempts to write save data
into its own directory, which is read-only in the Sugar environment.
Along the way several related bugs in the same code paths were fixed.

---

## Issues Fixed

- Fixes #29 — Activity tries to write to own directory

---

## What Was Wrong

### 1. Writing to read-only directory (Issue #29)
`save()` and `load()` in `utils.py` built the save path as:
```python
os.path.join(dir, 'data', 'Countries.dat')
```
When `SUGAR_ACTIVITY_ROOT` was not set, `dir` defaulted to `''`,
meaning the file was written to `data/Countries.dat` relative to CWD —
which is inside the activity bundle itself. In Sugar, the activity
bundle is read-only, so progress could never be saved.

### 2. File handles never closed (`f.close` vs `f.close()`)
Both `save()` and `load()` had:
```python
f.close   # ← this is just a reference, not a call
```
The file handles were never actually closed, which can cause data loss
and resource leaks.

### 3. Overly broad exception handling
Both functions used `except BaseException` which silently swallows
`KeyboardInterrupt` and `SystemExit`. This means Ctrl+C during a save
would be caught and ignored — a bug.

### 4. `utils.py` importing itself
`utils.py` had `import utils` at the top — a module importing itself.
This causes a circular import and was the reason `utils.CREAM` was
being referenced as `utils.CREAM` inside the same file instead of
just `CREAM`.

### 5. Unused import
`import copy` was present but `copy` is never used anywhere in the
codebase.

### 6. `check_response()` crash in `Countries.py`
`ctry.check()` can return `(-1, None)` when the input is unrecognised.
The original `check_response()` did not guard against `ans=None`,
causing a `TypeError` crash on `ans[:1]`.

### 7. `proximity()` crash on first click
`down_event` is initialised to `None` and stays `None` until the first
`MOUSEBUTTONDOWN`. If `MOUSEBUTTONUP` fired before any `MOUSEBUTTONDOWN`
(e.g. on activity startup), `proximity(event, None)` would throw
`AttributeError`.

---

## Changes Made

### `utils.py`
- Added `_get_data_dir()` helper that returns:
  - `$SUGAR_ACTIVITY_ROOT/data/` when running inside Sugar
  - `~/.local/share/countries-activity/` when running standalone
    (XDG-compliant, user-writable, created automatically if missing)
- Both `save()` and `load()` now call `_get_data_dir()` — the
  `SUGAR_ACTIVITY_ROOT` logic is still there, just written once
  instead of duplicated in two functions
- `save()` rewritten using `with open(...)` for guaranteed file closure
- `load()` uses `finally: f.close()` for guaranteed file closure
- `except BaseException` narrowed to `except OSError` (file open) and
  `except Exception` (load parsing)
- Removed `import utils` (self-import / circular import bug)
- Removed `import copy` (unused)
- Fixed `utils.CREAM` → `CREAM` in `message1()` (was only needed
  because of the self-import)

### `Countries.py`
- `check_response()`: added guard for `ans is None` before `ans[:1]`
  to prevent `TypeError` when `ctry.check()` returns no match
- `run()`: added `down_event is not None` guard before both
  `proximity()` calls to prevent `AttributeError` on early mouse events

---

## Testing

Tested standalone on Ubuntu 24 (Wayland + XWayland) with:
```
GDK_BACKEND=x11 SDL_VIDEODRIVER=x11 sugar-activity3
```
- Activity launches without errors
- Sound plays correctly
- Save/load works — data written to `~/.local/share/countries-activity/`
- No crash on first click or invalid country input

##Screenshot 

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/b3178c30-0810-4e49-9fcd-eba953386d03" />

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/f35bf2f8-2b4a-406f-bc0b-aef228ea2a4d" />

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/8958b8c3-c049-4823-a2d3-dedc9dabbc47" />


